### PR TITLE
Check for x-vs-store-code header (TLD support)

### DIFF
--- a/forceStorecode.ts
+++ b/forceStorecode.ts
@@ -10,6 +10,9 @@ export const forceStorecode = async (context, { url }) => {
     if (url.startsWith('dist/')) {
       return res.status(404).send('Not found')
     }
+    if (req.headers['x-vs-store-code']) {
+      return
+    }
     const { storeViews } = store.state.config
     const storeCode = storeCodeFromRoute(url)
     if (storeViews.multistore && storeViews.forcePrefix && !storeCode) {

--- a/store.ts
+++ b/store.ts
@@ -2,6 +2,7 @@ import { Module } from 'vuex'
 import store from '@vue-storefront/core/store'
 import RootState from '@vue-storefront/core/types/RootState'
 import { isServer } from '@vue-storefront/core/helpers'
+import filter from 'lodash-es/filter'
 
 export const module: Module<any, RootState> = {
   namespaced: true,
@@ -11,9 +12,7 @@ export const module: Module<any, RootState> = {
     },
     storeViews: () => {
       const { config } = store.state
-      const stores = config.storeViews.mapStoreUrlsFor
-      const { storeViews } = config
-      return stores.map(store => storeViews[store])
+      return filter(config.storeViews, prop => prop.hasOwnProperty('storeCode') && prop.disabled === false)
     },
     isCurrent: (state, getters) => {
       if (isServer) {


### PR DESCRIPTION
* Adds support for using TLD url structure (site.se) as opposed to subfolder structure (site.com/se). It needs incoming http requests to have the `x-vs-store-code` header set.
* Also populates the store-picker with ALL enabled sites instead of just the sites defined in `config.storeViews.mapStoreUrlsFor`, which is a config property originally used for a totally different functionality and cannot be (ab)used here anymore since TLD storeViews should not be in the `mapStoreUrlsFor` array.

TODO:
* [x] Fix `storeViews` getter to not rely on `config.storeViews.mapStoreUrlsFor`